### PR TITLE
Fix grain reference persistence

### DIFF
--- a/CouchBaseStorage/CouchBaseProviders.csproj
+++ b/CouchBaseStorage/CouchBaseProviders.csproj
@@ -46,16 +46,15 @@
       <HintPath>..\packages\Linq2Couchbase.1.2.1\lib\net45\Couchbase.Linq.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Couchbase.NetClient, Version=2.3.10.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\CouchbaseNetClient.2.3.10\lib\net45\Couchbase.NetClient.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.1.1.0\lib\netstandard1.1\Microsoft.Extensions.DependencyInjection.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.1.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Couchbase.NetClient, Version=2.4.2.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
+      <HintPath>..\packages\CouchbaseNetClient.2.4.2\lib\net45\Couchbase.NetClient.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/CouchBaseStorage/app.config
+++ b/CouchBaseStorage/app.config
@@ -8,7 +8,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Couchbase.NetClient" publicKeyToken="05e9c6b5a9ec94c2" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.3.10.0" newVersion="2.3.10.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.4.2.0" newVersion="2.4.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/CouchBaseStorage/packages.config
+++ b/CouchBaseStorage/packages.config
@@ -3,7 +3,7 @@
   <package id="Castle.Core" version="3.3.3" targetFramework="net452" />
   <package id="Common.Logging" version="3.3.1" targetFramework="net452" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net452" />
-  <package id="CouchbaseNetClient" version="2.3.10" targetFramework="net452" />
+  <package id="CouchbaseNetClient" version="2.4.2" targetFramework="net452" />
   <package id="ILRepack" version="2.0.12" targetFramework="net452" />
   <package id="Linq2Couchbase" version="1.2.1" targetFramework="net452" />
   <package id="Microsoft.Extensions.DependencyInjection" version="1.1.0" targetFramework="net452" />
@@ -27,7 +27,7 @@
   <package id="System.Linq" version="4.3.0" targetFramework="net452" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net452" />
   <package id="System.Linq.Queryable" version="4.3.0" targetFramework="net452" />
-  <package id="System.Net.Http" version="4.3.0" targetFramework="net452" />
+  <package id="System.Net.Http" version="4.3.1" targetFramework="net452" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net452" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net452" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net452" />

--- a/CouchBaseStorageTests/CouchBaseStorageTests.csproj
+++ b/CouchBaseStorageTests/CouchBaseStorageTests.csproj
@@ -47,8 +47,8 @@
       <HintPath>..\packages\Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Couchbase.NetClient, Version=2.3.10.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\CouchbaseNetClient.2.3.10\lib\net45\Couchbase.NetClient.dll</HintPath>
+    <Reference Include="Couchbase.NetClient, Version=2.4.2.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
+      <HintPath>..\packages\CouchbaseNetClient.2.4.2\lib\net45\Couchbase.NetClient.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">

--- a/CouchBaseStorageTests/app.config
+++ b/CouchBaseStorageTests/app.config
@@ -24,7 +24,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Couchbase.NetClient" publicKeyToken="05e9c6b5a9ec94c2" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.3.10.0" newVersion="2.3.10.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.4.2.0" newVersion="2.4.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />

--- a/CouchBaseStorageTests/packages.config
+++ b/CouchBaseStorageTests/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
-  <package id="CouchbaseNetClient" version="2.3.10" targetFramework="net452" />
+  <package id="CouchbaseNetClient" version="2.4.2" targetFramework="net452" />
   <package id="Microsoft.Extensions.DependencyInjection" version="1.1.0" targetFramework="net452" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.1.0" targetFramework="net452" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net452" />
@@ -25,7 +25,7 @@
   <package id="System.IO.Compression" version="4.3.0" targetFramework="net452" />
   <package id="System.Linq" version="4.3.0" targetFramework="net452" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net452" />
-  <package id="System.Net.Http" version="4.3.0" targetFramework="net452" />
+  <package id="System.Net.Http" version="4.3.1" targetFramework="net452" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net452" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net452" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net452" />

--- a/TestGrains/CouchBaseWithReferenceStorageGrain.cs
+++ b/TestGrains/CouchBaseWithReferenceStorageGrain.cs
@@ -55,7 +55,7 @@ namespace TestGrains
             //  Reference another grain to include into state persistence
             var referencedGrainId = this.GetPrimaryKey();
             State.StoredReferenceGrain = this.GrainFactory.GetGrain<IStoredReferenceGrain>(referencedGrainId);
-            State.StoredReferenceGrain.ReferenceMe(referenceTag);
+            State.StoredReferenceGrain.SetReferenceState(referenceTag);
 
             return TaskDone.Done;
         }

--- a/TestGrains/CouchBaseWithReferenceStorageGrain.cs
+++ b/TestGrains/CouchBaseWithReferenceStorageGrain.cs
@@ -6,7 +6,7 @@ namespace TestGrains
     using System;
 
     /// <summary>
-    /// Contract for a grain that references another grain, also persisting other grain's reference into this grain's state.
+    /// A grain that references another grain, also persisting other grain's reference into this grain's state.
     /// </summary>
     public interface ICouchBaseWithGrainReferenceStorageGrain : IGrainWithGuidKey
     {
@@ -50,6 +50,7 @@ namespace TestGrains
             await ReadStateAsync();
         }
 
+        /// <inheritdoc />
         public Task ReferenceOtherGrain(string referenceTag)
         {
             //  Reference another grain to include into state persistence

--- a/TestGrains/CouchBaseWithReferenceStorageGrain.cs
+++ b/TestGrains/CouchBaseWithReferenceStorageGrain.cs
@@ -1,0 +1,84 @@
+using System.Threading.Tasks;
+using Orleans;
+
+namespace TestGrains
+{
+    using System;
+
+    /// <summary>
+    /// Contract for a grain that references another grain, also persisting other grain's reference into this grain's state.
+    /// </summary>
+    public interface ICouchBaseWithGrainReferenceStorageGrain : IGrainWithGuidKey
+    {
+        Task Read();
+
+        /// <summary>
+        /// References another grain for inclusion into this grain's state.
+        /// </summary>
+        /// <param name="referenceTag">Tag to be applied into referenced grain's state.</param>
+        Task ReferenceOtherGrain(string referenceTag);
+
+        Task Write();
+
+        Task<string> GetReferencedTag();
+
+        Task<DateTime> GetReferencedAt();
+
+        Task Delete();
+    }
+
+    public class ReferencedGrainState
+    {
+        public IStoredReferenceGrain StoredReferenceGrain { get; set; }
+    }
+
+    /// <inheritdoc />
+    public class CouchBaseWithGrainReferenceStorageGrain : Grain<ReferencedGrainState>, ICouchBaseWithGrainReferenceStorageGrain
+    {
+        public override Task OnActivateAsync()
+        {
+            if (State == null)
+            {
+                State = new ReferencedGrainState();
+            }
+
+            return base.OnActivateAsync();
+        }
+
+        public async Task Read()
+        {
+            await ReadStateAsync();
+        }
+
+        public Task ReferenceOtherGrain(string referenceTag)
+        {
+            //  Reference another grain to include into state persistence
+            var referencedGrainId = this.GetPrimaryKey();
+            State.StoredReferenceGrain = this.GrainFactory.GetGrain<IStoredReferenceGrain>(referencedGrainId);
+            State.StoredReferenceGrain.ReferenceMe(referenceTag);
+
+            return TaskDone.Done;
+        }
+
+        public Task Write()
+        {
+            return WriteStateAsync();
+        }
+
+        public async Task Delete()
+        {
+            await ClearStateAsync();
+            State.StoredReferenceGrain = null;
+        }
+
+        public async Task<string> GetReferencedTag()
+        {
+            return await State.StoredReferenceGrain.GetReferenceTag();
+        }
+
+        public async Task<DateTime> GetReferencedAt()
+        {
+            return await State.StoredReferenceGrain.GetReferencedAt();
+        }
+    }
+}

--- a/TestGrains/StoredReferenceGrain.cs
+++ b/TestGrains/StoredReferenceGrain.cs
@@ -1,0 +1,64 @@
+﻿namespace TestGrains
+{
+    using System;
+    using System.Threading.Tasks;
+
+    using Orleans;
+
+    /// <summary>
+    /// Contract for a referenced grain.
+    /// </summary>
+    public interface IStoredReferenceGrain : IGrainWithGuidKey
+    {
+        /// <summary>
+        /// Adds reference tag and timestamp, and saves grain state.
+        /// </summary>
+        /// <param name="referenceTag"></param>
+        /// <returns></returns>
+        Task ReferenceMe(string referenceTag);
+
+        Task<string> GetReferenceTag();
+
+        Task<DateTime> GetReferencedAt();
+    }
+
+    public class ReferenceStorageData
+    {
+        public string ReferenceTag { get; set; }
+
+        public DateTime ReferencedAt { get; set; }
+    }
+
+    /// <inheritdoc />
+    public class StoredReferenceGrain : Grain<ReferenceStorageData>, IStoredReferenceGrain
+    {
+        public override Task OnActivateAsync()
+        {
+            if (State == null)
+            {
+                State = new ReferenceStorageData();
+
+            }
+
+            return base.OnActivateAsync();
+        }
+
+        /// <inheritdoc />
+        public async Task ReferenceMe(string referenceTag)
+        {
+            State.ReferenceTag = referenceTag;
+            State.ReferencedAt = DateTime.UtcNow;
+            await WriteStateAsync();
+        }
+
+        public Task<string> GetReferenceTag()
+        {
+            return Task.FromResult(State.ReferenceTag);
+        }
+
+        public Task<DateTime> GetReferencedAt()
+        {
+            return Task.FromResult(State.ReferencedAt);
+        }
+    }
+}

--- a/TestGrains/StoredReferenceGrain.cs
+++ b/TestGrains/StoredReferenceGrain.cs
@@ -6,7 +6,7 @@
     using Orleans;
 
     /// <summary>
-    /// Contract for a referenced grain.
+    /// Referenced grain.
     /// </summary>
     public interface IStoredReferenceGrain : IGrainWithGuidKey
     {

--- a/TestGrains/StoredReferenceGrain.cs
+++ b/TestGrains/StoredReferenceGrain.cs
@@ -15,7 +15,7 @@
         /// </summary>
         /// <param name="referenceTag"></param>
         /// <returns></returns>
-        Task ReferenceMe(string referenceTag);
+        Task SetReferenceState(string referenceTag);
 
         Task<string> GetReferenceTag();
 
@@ -44,7 +44,7 @@
         }
 
         /// <inheritdoc />
-        public async Task ReferenceMe(string referenceTag)
+        public async Task SetReferenceState(string referenceTag)
         {
             State.ReferenceTag = referenceTag;
             State.ReferencedAt = DateTime.UtcNow;

--- a/TestGrains/TestGrains.csproj
+++ b/TestGrains/TestGrains.csproj
@@ -56,9 +56,11 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CouchBaseWithReferenceStorageGrain.cs" />
     <Compile Include="CouchBaseStorageGrain.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\orleans.codegen.cs" />
+    <Compile Include="StoredReferenceGrain.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />


### PR DESCRIPTION
Fix for Couchbase storage provider to use Orleans default JSON serialization settings, enabling grain reference storage to succeed.

This is in reference to issue #6.