### PR TITLE
Add AppVeyor support

### DIFF
--- a/CouchBaseStorage/CouchBaseProviders.csproj
+++ b/CouchBaseStorage/CouchBaseProviders.csproj
@@ -103,6 +103,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="CouchBaseProviders.nuspec" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/CouchBaseStorage/CouchBaseProviders.nuspec
+++ b/CouchBaseStorage/CouchBaseProviders.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <title>$title$</title>
+    <authors>Ashkan Saeedi Mazdeh</authors>
+    <owners>OrleansContrib</owners>
+    <licenseUrl>https://opensource.org/licenses/MIT</licenseUrl>
+    <projectUrl>https://github.com/OrleansContrib/OrleansCouchbaseProvider</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Orleans grain and memebership storage provider for Couchbase.</description>
+    <copyright>Copyright 2017</copyright>
+    <tags>orleans storage provider couchbase</tags>
+  </metadata>
+</package>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,33 @@
+version: 0.1.{build}
+configuration: Release
+assembly_info:
+  patch: true
+  file: AssemblyInfo.*
+  assembly_version: "{version}"
+  assembly_file_version: "{version}"
+  assembly_informational_version: "{version}"
+cache:
+- packages -> **\packages.config
+before_build:
+- ps: nuget restore .\CouchBaseProviders.sln
+build:
+  publish_nuget: true
+  verbosity: minimal
+test: off
+deploy:
+- provider: NuGet
+  server: https://www.myget.org/F/couchbase-orleans-provider/api/v2/package
+  api_key:
+    secure: Cov0c7H0EvTAcF+4heoatFrtbFVvnz9PR0bTNbDKVTjcN47Vy1k2C3Siep6NsdA7
+  skip_symbols: true
+  artifact: /.*\.nupkg/
+  on:
+    appveyor_repo_tag: false
+- provider: NuGet
+  server: https://www.nuget.org/api/v2/package
+  api_key:
+    secure: RR63qaRziTfBDzeAHNLX/nNGavXrfzgXnSRniyuFgK493SzEw8DUa89bgVZHYSg8
+  skip_symbols: true
+  artifact: /.*\.nupkg/
+  on:
+    appveyor_repo_tag: true


### PR DESCRIPTION
- Adds AppVeyor support to build and create a nuget package for each commit.
- non-tag builds are pushed to MyGet feed for beta testing / early release
- tag builds are pushed to Nuget

Note: API keys are secure as they are encrypted and AppVeyor automatically decrypts when running. The keys are my personal keys too so will need updating at some point.

This is for issue #5 