### PR TITLE
Split server parameter to allow couchbase node endpoints

### DIFF
--- a/CouchBaseStorage/CouchBaseStorageProvider.cs
+++ b/CouchBaseStorage/CouchBaseStorageProvider.cs
@@ -63,7 +63,11 @@ namespace Orleans.Storage
 
             Couchbase.Configuration.Client.ClientConfiguration clientConfig = new Couchbase.Configuration.Client.ClientConfiguration();
             clientConfig.Servers.Clear();
-            clientConfig.Servers.Add(new Uri(server));
+            foreach (var s in server.Split(new[] {','}, StringSplitOptions.RemoveEmptyEntries))
+            {
+                clientConfig.Servers.Add(new Uri(s));
+            }
+
             clientConfig.BucketConfigs.Clear();
             clientConfig.BucketConfigs.Add(bucketName, new Couchbase.Configuration.Client.BucketConfiguration
             {


### PR DESCRIPTION
Split the server parameter by comma to allow multiple couchbase node endpoints.

Addresses issue #10 