### PR TITLE
Add support for full Couchbase config integration

### DIFF
--- a/CouchBaseStorage/Configuration/CouchbaseConfigurationExtensions.cs
+++ b/CouchBaseStorage/Configuration/CouchbaseConfigurationExtensions.cs
@@ -40,7 +40,8 @@ namespace CouchBaseProviders.Configuration
             // Assume provider properties client configuration
             var user = GetPropertyValue(properties, StorageConstants.PropertyNames.UserName, false);
             var password = GetPropertyValue(properties, StorageConstants.PropertyNames.Password, false);
-            var servers = GetPropertyValue(properties, StorageConstants.PropertyNames.Servers, true);
+            var servers = GetPropertyValue(properties, StorageConstants.PropertyNames.Server, false) ??
+                          GetPropertyValue(properties, StorageConstants.PropertyNames.Servers, true);
 
             var clientConfiguration = new ClientConfiguration();
 

--- a/CouchBaseStorage/Configuration/CouchbaseConfigurationExtensions.cs
+++ b/CouchBaseStorage/Configuration/CouchbaseConfigurationExtensions.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using Couchbase.Configuration.Client;
+using Couchbase.Configuration.Client.Providers;
+using Orleans.Providers;
+
+namespace CouchBaseProviders.Configuration
+{
+    /// <summary>
+    /// Couchbase configuration utility extension methods.
+    /// </summary>
+    public static class CouchbaseConfigurationExtensions
+    {
+        /// <summary>
+        /// Parses Orleans provider configuration into a <see cref="ClientConfiguration"/> instance.
+        /// </summary>
+        /// <param name="properties">Orleans <see cref="IProviderConfiguration.Properties"/>.</param>
+        /// <param name="storageBucketName">Name of bucket configured for grain state document storage.</param>
+        /// <returns>Parsed Couchbase client configuration.</returns>
+        public static ClientConfiguration ReadCouchbaseConfiguration(
+            this IDictionary<string, string> properties, 
+            out string storageBucketName)
+        {
+            // Determine target data bucket
+            storageBucketName = GetPropertyValue(properties, StorageConstants.PropertyNames.BucketName, true);
+
+            // Attempt with Couchbase client configuration section
+            var clientSectionName = GetPropertyValue(properties, StorageConstants.PropertyNames.ClientConfigurationSectionPath, false);
+            if (!string.IsNullOrWhiteSpace(clientSectionName))
+            {
+                var clientSection = (CouchbaseClientSection)ConfigurationManager.GetSection(clientSectionName);
+                if (clientSection == null)
+                {
+                    throw new ConfigurationErrorsException(string.Format("Section '{0}' has not been configured.", clientSectionName));
+                }
+                return new ClientConfiguration(clientSection);
+            }
+
+            // Assume provider properties client configuration
+            var user = GetPropertyValue(properties, StorageConstants.PropertyNames.UserName, false);
+            var password = GetPropertyValue(properties, StorageConstants.PropertyNames.Password, false);
+            var servers = GetPropertyValue(properties, StorageConstants.PropertyNames.Servers, true);
+
+            var clientConfiguration = new ClientConfiguration();
+
+            clientConfiguration.Servers.Clear();
+            foreach (var s in servers.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                clientConfiguration.Servers.Add(new Uri(s));
+            }
+
+            clientConfiguration.BucketConfigs.Clear();
+            clientConfiguration.BucketConfigs.Add(storageBucketName, new Couchbase.Configuration.Client.BucketConfiguration
+            {
+                BucketName = storageBucketName,
+                Username = user,
+                Password = password
+            });
+
+            return clientConfiguration;
+        }
+
+        private static string GetPropertyValue(IDictionary<string, string> properties, string key, bool isRequired)
+        {
+            string value = null;
+            if (!properties.TryGetValue(key, out value) && isRequired && string.IsNullOrWhiteSpace(value))
+            {
+                throw new ConfigurationErrorsException(string.Format("{0} property not set.", key));
+            }
+
+            return value;
+        }
+    }
+}

--- a/CouchBaseStorage/Configuration/StorageProviderConstants.cs
+++ b/CouchBaseStorage/Configuration/StorageProviderConstants.cs
@@ -1,0 +1,39 @@
+﻿using Couchbase.Configuration.Client.Providers;
+using Orleans.Providers;
+
+namespace CouchBaseProviders.Configuration
+{
+    public static class StorageConstants
+    {
+        /// <summary>
+        /// Expected property names specified into <see cref="IProviderConfiguration.Properties"/>.
+        /// </summary>
+        public static class PropertyNames
+        {
+            /// <summary>
+            /// Path to target <see cref="CouchbaseClientSection"/> configuration XML element.
+            /// </summary>
+            public static readonly string ClientConfigurationSectionPath = "ClientConfigurationSectionPath";
+
+            /// <summary>
+            /// List of URI(s) to target Couchbase cluster node(s).
+            /// </summary>
+            public static readonly string Servers = "Servers";
+
+            /// <summary>
+            /// Target bucket name.
+            /// </summary>
+            public static readonly string BucketName = "BucketName";
+
+            /// <summary>
+            /// Bucket user name.
+            /// </summary>
+            public static readonly string UserName = "UserName";
+
+            /// <summary>
+            /// Bucket password.
+            /// </summary>
+            public static readonly string Password = "Password";
+        }
+    }
+}

--- a/CouchBaseStorage/Configuration/StorageProviderConstants.cs
+++ b/CouchBaseStorage/Configuration/StorageProviderConstants.cs
@@ -21,6 +21,14 @@ namespace CouchBaseProviders.Configuration
             public static readonly string Servers = "Servers";
 
             /// <summary>
+            /// List of URI(s) to target Couchbase cluster node(s).
+            /// </summary>
+            /// <remarks>
+            /// An alternative to the <see cref="Servers"/> property, maintained for backward compatibility.
+            /// </remarks>
+            public static readonly string Server = "Server";
+
+            /// <summary>
             /// Target bucket name.
             /// </summary>
             public static readonly string BucketName = "BucketName";

--- a/CouchBaseStorage/CouchBaseProviders.csproj
+++ b/CouchBaseStorage/CouchBaseProviders.csproj
@@ -79,6 +79,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Numerics" />
@@ -95,11 +96,13 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BaseJSONStorageProvider.cs" />
+    <Compile Include="Configuration\CouchbaseConfigurationExtensions.cs" />
     <Compile Include="CouchBaseMembershipProvider.cs" />
     <Compile Include="CouchBaseStorageProvider.cs" />
     <Compile Include="IJSONStateDataManager.cs" />
     <Compile Include="SerializableMembership.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Configuration\StorageProviderConstants.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/CouchBaseStorageTests/CouchBaseGrainStorageTests.cs
+++ b/CouchBaseStorageTests/CouchBaseGrainStorageTests.cs
@@ -23,7 +23,7 @@ namespace CouchBaseStorageTests
                 c.Globals.RegisterStorageProvider<Orleans.Storage.OrleansCouchBaseStorage>("Default",
                     new Dictionary<string, string>()
                             {
-                                { "Server","http://localhost:8091" },
+                                { "Servers","http://localhost:8091" },
                                 { "UserName","" },
                                 { "Password","" },
                                 { "BucketName","default" }

--- a/CouchBaseStorageTests/CouchBaseStorageTests.csproj
+++ b/CouchBaseStorageTests/CouchBaseStorageTests.csproj
@@ -89,6 +89,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Numerics" />
@@ -124,6 +125,7 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="CouchbaseConfigurationExtensionsTests.cs" />
     <Compile Include="CouchBaseMembershipDataManagerTests.cs" />
     <Compile Include="CouchBaseDataManagerTests.cs" />
     <Compile Include="CouchBaseGrainStorageTests.cs" />

--- a/CouchBaseStorageTests/CouchbaseConfigurationExtensionsTests.cs
+++ b/CouchBaseStorageTests/CouchbaseConfigurationExtensionsTests.cs
@@ -32,16 +32,18 @@ namespace CouchBaseStorageTests
             Assert.Equal("orleans-storage", storageBucketName);
             Assert.Equal(storageBucketName, clientConfiguration.BucketConfigs.ElementAt(0).Key);
         }
-
-        [Fact]
-        public void ReadsPropertiesParsesSingleNodeConfigurationTest()
+        
+        [Theory]
+        [InlineData("Servers")]
+        [InlineData("Server")]
+        public void ReadsPropertiesParsesSingleNodeConfigurationTest(string nodesUriParameterName)
         {
             // Arrange
             const string singleNodeUri = "http://couchnode02:8091";
             var properties =
                 new Dictionary<string, string>()
                 {
-                    {"Servers", singleNodeUri},
+                    {nodesUriParameterName, singleNodeUri},
                     {"BucketName", "orleans-storage"}
                 };
 
@@ -54,8 +56,10 @@ namespace CouchBaseStorageTests
             Assert.Equal(new Uri(singleNodeUri), clientConfiguration.Servers.ElementAt(0));
         }
 
-        [Fact]
-        public void ReadsPropertiesParsesWithMultipleNodeConfigurationTest()
+        [Theory]
+        [InlineData("Servers")]
+        [InlineData("Server")]
+        public void ReadsPropertiesParsesWithMultipleNodeConfigurationTest(string nodesUriParameterName)
         {
             // Arrange
             const string multipleNodeUris =
@@ -64,7 +68,7 @@ namespace CouchBaseStorageTests
             var properties =
                 new Dictionary<string, string>()
                 {
-                    {"Servers", multipleNodeUris},
+                    {nodesUriParameterName, multipleNodeUris},
                     {"BucketName", "orleans-storage"}
                 };
 
@@ -78,8 +82,10 @@ namespace CouchBaseStorageTests
             Assert.Equal(new Uri("http://couchnode02:8091"), clientConfiguration.Servers.ElementAt(1));
         }
 
-        [Fact]
-        public void ReadsPropertiesParsesBucketCredentialsConfigurationTest()
+        [Theory]
+        [InlineData("Servers")]
+        [InlineData("Server")]
+        public void ReadsPropertiesParsesBucketCredentialsConfigurationTest(string nodesUriParameterName)
         {
             // Arrange
             const string userName = "bucketUser";
@@ -88,7 +94,7 @@ namespace CouchBaseStorageTests
             var properties =
                 new Dictionary<string, string>()
                 {
-                    {"Servers", "http://couchnode01:8091"},
+                    {nodesUriParameterName, "http://couchnode01:8091"},
                     {"BucketName", "orleans-storage"},
                     {"UserName", userName},
                     {"Password", password}

--- a/CouchBaseStorageTests/CouchbaseConfigurationExtensionsTests.cs
+++ b/CouchBaseStorageTests/CouchbaseConfigurationExtensionsTests.cs
@@ -1,0 +1,169 @@
+﻿using System;
+using CouchBaseProviders.Configuration;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using Xunit;
+
+namespace CouchBaseStorageTests
+{
+    public class CouchbaseConfigurationExtensionsTests
+    {
+        [Fact]
+        public void ReadsPropertiesParsesClientConfigurationSectionTest()
+        {
+            // Arrange
+            var properties = 
+                new Dictionary<string, string>()
+                {
+                    {"ClientConfigurationSectionPath", "couchbaseClients/couchbase"},
+                    {"BucketName", "orleans-storage"}
+                };
+
+            string storageBucketName = null;
+
+            // Act
+            var clientConfiguration = properties.ReadCouchbaseConfiguration(out storageBucketName);
+
+            // Assert
+            Assert.Equal(3, clientConfiguration.Servers.Count);
+            Assert.Equal(new Uri("http://couchnode02:8091"), clientConfiguration.Servers.ElementAt(1));
+            Assert.Equal(1, clientConfiguration.BucketConfigs.Count);
+            Assert.Equal("orleans-storage", storageBucketName);
+            Assert.Equal(storageBucketName, clientConfiguration.BucketConfigs.ElementAt(0).Key);
+        }
+
+        [Fact]
+        public void ReadsPropertiesParsesSingleNodeConfigurationTest()
+        {
+            // Arrange
+            const string singleNodeUri = "http://couchnode02:8091";
+            var properties =
+                new Dictionary<string, string>()
+                {
+                    {"Servers", singleNodeUri},
+                    {"BucketName", "orleans-storage"}
+                };
+
+            string storageBucketName = null;
+            // Act
+            var clientConfiguration = properties.ReadCouchbaseConfiguration(out storageBucketName);
+
+            // Assert
+            Assert.Equal(1, clientConfiguration.Servers.Count);
+            Assert.Equal(new Uri(singleNodeUri), clientConfiguration.Servers.ElementAt(0));
+        }
+
+        [Fact]
+        public void ReadsPropertiesParsesWithMultipleNodeConfigurationTest()
+        {
+            // Arrange
+            const string multipleNodeUris =
+                "http://couchnode01:8091,http://couchnode02:8091,http://couchnode03:8091";
+
+            var properties =
+                new Dictionary<string, string>()
+                {
+                    {"Servers", multipleNodeUris},
+                    {"BucketName", "orleans-storage"}
+                };
+
+            string storageBucketName = null;
+
+            // Act
+            var clientConfiguration = properties.ReadCouchbaseConfiguration(out storageBucketName);
+
+            // Assert
+            Assert.Equal(3, clientConfiguration.Servers.Count);
+            Assert.Equal(new Uri("http://couchnode02:8091"), clientConfiguration.Servers.ElementAt(1));
+        }
+
+        [Fact]
+        public void ReadsPropertiesParsesBucketCredentialsConfigurationTest()
+        {
+            // Arrange
+            const string userName = "bucketUser";
+            const string password = "bucketPassword";
+
+            var properties =
+                new Dictionary<string, string>()
+                {
+                    {"Servers", "http://couchnode01:8091"},
+                    {"BucketName", "orleans-storage"},
+                    {"UserName", userName},
+                    {"Password", password}
+                };
+
+            string storageBucketName = null;
+
+            // Act
+            var clientConfiguration = properties.ReadCouchbaseConfiguration(out storageBucketName);
+
+            // Assert
+            Assert.Equal(1, clientConfiguration.BucketConfigs.Count);
+            var bucketConfig = clientConfiguration.BucketConfigs.Single();
+            Assert.Equal(userName, bucketConfig.Value.Username);
+            Assert.Equal(password, bucketConfig.Value.Password);
+        }
+
+        [Fact]
+        public void ReadsPropertiesFailsWithInexistentClientConfigurationSectionNameTest()
+        {
+            // Arrange
+            const string badSectionName = "couchbaseClients/inexistent";
+            var properties =
+                new Dictionary<string, string>()
+                {
+                    {"ClientConfigurationSectionPath", badSectionName},
+                    {"BucketName", "orleans-storage"}
+                };
+
+            string storageBucketName = null;
+
+            // Act / Assert
+            var configurationErrorsException =
+                Assert.Throws<ConfigurationErrorsException>(
+                    () => properties.ReadCouchbaseConfiguration(out storageBucketName));
+            Assert.Equal(string.Format("Section '{0}' has not been configured.", badSectionName),
+                configurationErrorsException.Message);
+        }
+
+        [Fact]
+        public void ReadPropertiesFailsWhenMissingBucketNameConfigurationTest()
+        {
+            // Arrange
+            var properties =
+                new Dictionary<string, string>()
+                {
+                    {"ClientConfigurationSectionPath", "couchbaseClients/couchbase"}
+                };
+
+            string storageBucketName = null;
+
+            // Act / Assert
+            var configurationErrorsException =
+                Assert.Throws<ConfigurationErrorsException>(
+                    () => properties.ReadCouchbaseConfiguration(out storageBucketName));
+            Assert.Equal("BucketName property not set.", configurationErrorsException.Message);
+        }
+        
+        [Fact]
+        public void ReadPropertiesFailsWhenMissingClientConfigurationSectionAndServersTest()
+        {
+            // Arrange
+            var properties =
+                new Dictionary<string, string>()
+                {
+                    {"BucketName", "orleans-storage"}
+                };
+
+            string storageBucketName = null;
+
+            // Act / Assert
+            var configurationErrorsException =
+                Assert.Throws<ConfigurationErrorsException>(
+                    () => properties.ReadCouchbaseConfiguration(out storageBucketName));
+            Assert.Equal("Servers property not set.", configurationErrorsException.Message);
+        }
+    }
+}

--- a/CouchBaseStorageTests/app.config
+++ b/CouchBaseStorageTests/app.config
@@ -1,5 +1,22 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <configSections>
+    <sectionGroup name="couchbaseClients">
+      <section name="couchbase" type="Couchbase.Configuration.Client.Providers.CouchbaseClientSection, Couchbase.NetClient" />
+    </sectionGroup>
+  </configSections>
+  <couchbaseClients>
+    <couchbase>
+      <servers>
+        <add uri="http://couchnode01:8091"></add>
+        <add uri="http://couchnode02:8091"></add>
+        <add uri="http://couchnode03:8091"></add>
+      </servers>
+      <buckets>
+        <add name="orleans-storage" useSsl="false" />
+      </buckets>
+    </couchbase>
+  </couchbaseClients>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>


### PR DESCRIPTION
Enables storage provider config to specify a configuration section name to be applied for full Couchbase configuration upon provider initialization.

Addresses remaining requirement as per issue #10.